### PR TITLE
Address #2 - Allow scan of small files.

### DIFF
--- a/src/clamav_large_archive_scanner/main.py
+++ b/src/clamav_large_archive_scanner/main.py
@@ -153,7 +153,13 @@ def _scan(path, min_size, ignore_size, fail_fast, all_match, tmp_dir):
     unpacked_ctxs = _unpack(path, True, min_size, ignore_size, tmp_dir)
 
     # scan the unpacked dirs
-    files_clean = scanner.clamdscan(unpacked_ctxs, fail_fast, all_match)
+    if len(unpacked_ctxs) == 0:
+        # Nothing was unpacked, just run a single clamdscan on the file
+        single_ctx = Contexts.UnpackContext(detect.file_meta_from_path(path), tmp_dir)
+        single_ctx.unpacked_dir_location = path
+        files_clean = scanner.clamdscan([single_ctx], fail_fast, all_match)
+    else:
+        files_clean = scanner.clamdscan(unpacked_ctxs, fail_fast, all_match)
 
     # Cleanup
     cleaner.cleanup_recursive(path, tmp_dir)

--- a/src/clamav_large_archive_scanner/test/test_main.py
+++ b/src/clamav_large_archive_scanner/test/test_main.py
@@ -208,6 +208,27 @@ def test_scan_error_all_match_and_ff(mock_scanner, mock_cleaner, mock_unpacker, 
     _assert_no_cleanup(mock_cleaner)
 
 
+def test_deepscan_no_unpack(mock_scanner, mock_cleaner, mock_unpacker, mock_detect, testcase_file_meta):
+    from clamav_large_archive_scanner.main import _scan
+    _set_clamdscan_present(mock_scanner, True)
+    too_small_meta = testcase_file_meta
+    too_small_meta.size_raw = 0
+    _set_detect_file_meta_from_path(mock_detect, too_small_meta)
+
+    _set_clamdscan_clean(mock_scanner, True)
+
+    _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, False, EXPECTED_TMP_DIR)
+
+    _assert_no_unpack(mock_detect, mock_unpacker)
+    mock_scanner.clamdscan.assert_called_once()
+    _assert_no_cleanup(mock_cleaner)
+
+    scanner_call_ctxs = mock_scanner.clamdscan.call_args[0][0]
+    assert len(scanner_call_ctxs) == 1
+    assert scanner_call_ctxs[0].unpacked_dir_location == EXPECTED_PATH
+
+
+
 def test_unpack_non_recursive(mock_unpacker, mock_detect, testcase_file_meta):
     from clamav_large_archive_scanner.main import _unpack
     _set_default_unpack_mocks(mock_unpacker, mock_detect, testcase_file_meta)


### PR DESCRIPTION
Allow scanning of files under min-size when using `scan`.

This is a cherry-pick from the internal repo.