### PR TITLE
Change Scan RV to be Worst of Clamdscan

### DIFF
--- a/src/clamav_large_archive_scanner/test/test_main.py
+++ b/src/clamav_large_archive_scanner/test/test_main.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-
+from typing import List
 from unittest.mock import MagicMock
 
 import click
@@ -35,6 +35,7 @@ from pytest_mock import MockerFixture
 
 import common
 from clamav_large_archive_scanner.lib.file_data import FileMetadata, FileType
+from clamav_large_archive_scanner.lib.scanner import ScanResult
 
 EXPECTED_PATH = '/some/path/some_archive.tar'
 EXPECTED_MIN_SIZE = '100M'
@@ -42,6 +43,10 @@ EXPECTED_MIN_SIZE_BYTES = 100 * 1024 * 1024
 EXPECTED_TMP_DIR = '/tmp'
 EXPECTED_UNPACKED_DIRS = ['/tmp/some_dir_1', '/tmp/some_dir_2', '/tmp/some_dir_3']
 EXPECTED_UNPACKED_DIR = '/tmp/some_dir_4'
+
+GOOD_SCAN_RESULT = ScanResult(EXPECTED_PATH, 0)
+VIRUS_SCAN_RESULT = ScanResult(EXPECTED_PATH, 1)
+ERROR_SCAN_RESULT = ScanResult(EXPECTED_PATH, 2)
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -111,8 +116,8 @@ def _set_default_unpack_mocks(mock_unpacker, mock_detect, testcase_file_meta):
     _set_detect_file_meta_from_path(mock_detect, testcase_file_meta)
 
 
-def _set_clamdscan_clean(mock_scanner, is_clean: bool):
-    mock_scanner.clamdscan.return_value = is_clean
+def _set_clamdscan_rv(mock_scanner, results: List[ScanResult]):
+    mock_scanner.clamdscan.return_value = results
 
 
 def _assert_unpack_logic(mock_detect, mock_unpacker, expected_path, expected_recursive, expected_min_size_bytes,
@@ -152,9 +157,11 @@ def test_scan_happy_path(mock_scanner, mock_cleaner, mock_unpacker, mock_detect,
     from clamav_large_archive_scanner.main import _scan
     _set_clamdscan_present(mock_scanner, True)
     _set_default_unpack_mocks(mock_unpacker, mock_detect, testcase_file_meta)
-    _set_clamdscan_clean(mock_scanner, True)
+    scan_results = [GOOD_SCAN_RESULT]
+    _set_clamdscan_rv(mock_scanner, scan_results)
 
-    _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, False, EXPECTED_TMP_DIR)
+    scan_rv = _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, False, EXPECTED_TMP_DIR)
+    assert scan_rv == 0
 
     _assert_unpack_logic(mock_detect, mock_unpacker, EXPECTED_PATH, True, EXPECTED_MIN_SIZE_BYTES, EXPECTED_TMP_DIR,
                          testcase_file_meta)
@@ -167,9 +174,11 @@ def test_scan_happy_path_all_match(mock_scanner, mock_cleaner, mock_unpacker, mo
     from clamav_large_archive_scanner.main import _scan
     _set_clamdscan_present(mock_scanner, True)
     _set_default_unpack_mocks(mock_unpacker, mock_detect, testcase_file_meta)
-    _set_clamdscan_clean(mock_scanner, True)
+    scan_results = [GOOD_SCAN_RESULT]
+    _set_clamdscan_rv(mock_scanner, scan_results)
 
-    _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, True, EXPECTED_TMP_DIR)
+    scan_rv = _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, True, EXPECTED_TMP_DIR)
+    assert scan_rv == 0
 
     _assert_unpack_logic(mock_detect, mock_unpacker, EXPECTED_PATH, True, EXPECTED_MIN_SIZE_BYTES, EXPECTED_TMP_DIR,
                          testcase_file_meta)
@@ -182,16 +191,37 @@ def test_scan_virus_fail_fast(mock_scanner, mock_cleaner, mock_unpacker, mock_de
     from clamav_large_archive_scanner.main import _scan
     _set_clamdscan_present(mock_scanner, True)
     _set_default_unpack_mocks(mock_unpacker, mock_detect, testcase_file_meta)
-    _set_clamdscan_clean(mock_scanner, False)
+    scan_results = [GOOD_SCAN_RESULT, VIRUS_SCAN_RESULT]
+    _set_clamdscan_rv(mock_scanner, scan_results)
 
-    with pytest.raises(click.ClickException) as e:
-        _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, True, False, EXPECTED_TMP_DIR)
+    scan_rv = _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, True, False, EXPECTED_TMP_DIR)
+    assert scan_rv == 1
 
     _assert_unpack_logic(mock_detect, mock_unpacker, EXPECTED_PATH, True, EXPECTED_MIN_SIZE_BYTES, EXPECTED_TMP_DIR,
                          testcase_file_meta)
 
     mock_scanner.clamdscan.assert_called_once_with(EXPECTED_UNPACKED_DIRS, True, False)
     mock_cleaner.cleanup_recursive.assert_called_once_with(EXPECTED_PATH, EXPECTED_TMP_DIR)
+
+
+def test_scan_rv_iterations(mock_scanner, mock_cleaner, mock_unpacker, mock_detect, testcase_file_meta):
+    from clamav_large_archive_scanner.main import _scan
+    _set_clamdscan_present(mock_scanner, True)
+    _set_default_unpack_mocks(mock_unpacker, mock_detect, testcase_file_meta)
+
+    # Good, Virus, Error -> Virus
+    scan_results = [GOOD_SCAN_RESULT, VIRUS_SCAN_RESULT, ERROR_SCAN_RESULT]
+    _set_clamdscan_rv(mock_scanner, scan_results)
+
+    scan_rv = _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, False, EXPECTED_TMP_DIR)
+    assert scan_rv == 1
+
+    # Good, Error -> Error
+    scan_results = [GOOD_SCAN_RESULT, ERROR_SCAN_RESULT]
+    _set_clamdscan_rv(mock_scanner, scan_results)
+
+    scan_rv = _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, False, EXPECTED_TMP_DIR)
+    assert scan_rv == 2
 
 
 def test_scan_error_all_match_and_ff(mock_scanner, mock_cleaner, mock_unpacker, mock_detect, testcase_file_meta):
@@ -215,7 +245,8 @@ def test_deepscan_no_unpack(mock_scanner, mock_cleaner, mock_unpacker, mock_dete
     too_small_meta.size_raw = 0
     _set_detect_file_meta_from_path(mock_detect, too_small_meta)
 
-    _set_clamdscan_clean(mock_scanner, True)
+    scan_results = [GOOD_SCAN_RESULT]
+    _set_clamdscan_rv(mock_scanner, scan_results)
 
     _scan(EXPECTED_PATH, EXPECTED_MIN_SIZE, False, False, False, EXPECTED_TMP_DIR)
 


### PR DESCRIPTION
* Updated log levels during scan, most messages are now info.
* Updated return value (RV) of archive tool during scan, will now return the worst case RV of all archives scanned. RV is identical to clamdscan.
* Fixed minor log mistake for min value
* Updated UT to match

This is a cherry-pick from the internal repo