### PR TITLE
Allow Scan of Directories

### DIFF
--- a/src/clamav_large_archive_scanner/lib/scanner.py
+++ b/src/clamav_large_archive_scanner/lib/scanner.py
@@ -50,6 +50,9 @@ class ScanResult:
         else:
             return 'Unknown return code.'
 
+    def is_virus_found(self) -> bool:
+        return self.clamdscan_rv == 1
+
     def __str__(self):
         return f'{self.path}: {self._get_scancode_str()}'
 

--- a/src/clamav_large_archive_scanner/lib/unpack.py
+++ b/src/clamav_large_archive_scanner/lib/unpack.py
@@ -140,6 +140,9 @@ class DirFileUnpackHandler:
     def __init__(self, u_ctx: contexts.UnpackContext):
         self.u_ctx = u_ctx
 
+        # Set the "unpacked" location to the original directory
+        self.u_ctx.unpacked_dir_location = self.u_ctx.file_meta.path
+
     def unpack(self) -> contexts.UnpackContext:
         return self.u_ctx
 

--- a/src/clamav_large_archive_scanner/main.py
+++ b/src/clamav_large_archive_scanner/main.py
@@ -169,7 +169,10 @@ def _scan(path, min_size, ignore_size, fail_fast, all_match, tmp_dir) -> int:
     fast_log.info('=' * 80)
     fast_log.info('Scan Results, showing path and clamdscan return code')
     for result in scan_results:
-        fast_log.info(str(result))
+        if result.is_virus_found():
+            fast_log.warn(str(result))
+        else:
+            fast_log.info(str(result))
     fast_log.info('=' * 80)
 
     # return value of scan is the "worst" result of the scan, virus > error > clean

--- a/src/clamav_large_archive_scanner/test/test_scanner.py
+++ b/src/clamav_large_archive_scanner/test/test_scanner.py
@@ -179,3 +179,9 @@ def test_clamdsan_virus_and_errors(mock_subprocess):
     results = clamdscan(EXPECTED_CTXS, False, False)
 
     assert results == EXPECTED_SCAN_RESULTS
+
+
+def test_scan_result_is_virus():
+    assert ScanResult('some_file', 1).is_virus_found()
+    assert not ScanResult('some_file', 0).is_virus_found()
+    assert not ScanResult('some_file', 2).is_virus_found()

--- a/src/clamav_large_archive_scanner/test/test_unpack.py
+++ b/src/clamav_large_archive_scanner/test/test_unpack.py
@@ -305,6 +305,7 @@ def test_dir_unpacker():
     unpack_ctx = unpacker.unpack()
 
     assert unpack_ctx == mock_u_ctx
+    assert unpack_ctx.unpacked_dir_location == EXPECTED_ARCHIVE_PATH
 
     mock_u_ctx.create_tmp_dir.assert_not_called()
 


### PR DESCRIPTION
Fixed an issue where contexts for directories didn't have an unpack location, and therefore couldn't be scanned

Also changed some log levels so that viruses come as `warn` and not `info`

Fixes #7 